### PR TITLE
Fix subline reset and correct README instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ Damit CORS vollständig für die Anfragen an die JIRA-API konfiguriert ist, müs
 
 ```bash
 # Verzeichnisinhalt über Port 8000 verfügbar machen
-python -m http.server 8000 d C:\path\to\tpm\www
+python -m http.server 8000 -d C:\path\to\tpm\www
 ```
 
 5. Browser öffnen: [`http://localhost:8000/index.html`](http://localhost:8000/index.html)

--- a/throughput.html
+++ b/throughput.html
@@ -140,7 +140,7 @@
 
           async function fetchData(){
             if(!s.selectedTeam||!s.jiraBaseUrl) return;
-            Object.assign(s,{loading:true,progress:0,weekRows:[],issueCount:0,minDate:null,maxDate:null,avg:null,median:null,sublineText:''});
+            Object.assign(s,{loading:true,progress:0,weekRows:[],issueCount:0,minDate:null,maxDate:null,avg:null,median:null,subline:''});
             const fid=s.selectedTeam.filterId; let jql=`filter=${fid}`;
             if(s.fromDate) jql+=` AND resolutiondate >= "${s.fromDate}"`;
             if(s.toDate)   jql+=` AND resolutiondate <= "${s.toDate} 23:59"`;


### PR DESCRIPTION
## Summary
- ensure `subline` is reset properly in throughput report
- fix README example command for starting a simple Python web server

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a4adf8d788323b2493978798756f2